### PR TITLE
Fix yaml ssh rosinstall syntax

### DIFF
--- a/install/kimera_vioros_ssh.rosinstall
+++ b/install/kimera_vioros_ssh.rosinstall
@@ -46,11 +46,11 @@
     local-name: Kimera-VIO-ROS
     uri: git@github.com:MIT-SPARK/Kimera-VIO-ROS.git
     version: master
--git:
+- git:
     local-name: glog_catkin
     uri: git@github.com:ethz-asl/glog_catkin.git
     version: master
--git:
+- git:
     local-name: gflags_catkin
     uri: git@github.com:ethz-asl/gflags_catkin.git
     version: master


### PR DESCRIPTION
ERROR in config: Invalid multiproject yaml format in [https://raw.githubusercontent.com/MIT-SPARK/Kimera-VIO-ROS/master/install/kimera_vioros_ssh.rosinstall]: while parsing a block collection
  in "<file>", line 1, column 1
expected <block end>, but found '?'
  in "<file>", line 49, column 1